### PR TITLE
Incremental checkpoint for Track2 readiness.

### DIFF
--- a/resolvers/dotnet/Azure.IoT.DeviceModelsRepository.CLI/Program.cs
+++ b/resolvers/dotnet/Azure.IoT.DeviceModelsRepository.CLI/Program.cs
@@ -64,13 +64,17 @@ namespace Azure.IoT.DeviceModelsRepository.CLI
             return loggerFactory.CreateLogger(typeof(Program));
         }
 
-
         private static ResolverClient InitializeClient(string repository, ILogger logger)
         {
-            ResolverClient client;
-            client = Directory.Exists(repository) ?
-                ResolverClient.FromLocalRepository(repository, logger) : ResolverClient.FromRemoteRepository(repository, logger);
-            return client;
+            if (Validations.IsRelativePath(repository))
+            {
+                repository = Path.GetFullPath(repository);
+            }
+
+            return new ResolverClient(
+                repository,
+                new ResolverClientOptions(DependencyResolutionOption.FromExpanded),
+                logger);
         }
 
         private static Command BuildExportCommand()
@@ -249,7 +253,7 @@ namespace Azure.IoT.DeviceModelsRepository.CLI
                 try
                 {
                     var newModels = await ModelImporter.ImportModels(modelFile, repository, force, logger);
-                    foreach(var model in newModels)
+                    foreach (var model in newModels)
                     {
                         var validationResult = await validateFile(model, repository.FullName, true, logger, parser);
                         if (validationResult != ReturnCodes.Success)

--- a/resolvers/dotnet/Azure.IoT.DeviceModelsRepository.CLI/Properties/launchSettings.json
+++ b/resolvers/dotnet/Azure.IoT.DeviceModelsRepository.CLI/Properties/launchSettings.json
@@ -1,58 +1,54 @@
 {
   "profiles": {
-    "Azure.DigitalTwins.Resolver.CLI.SmokeTests.ShowRemote": {
+    "Azure.IoT.DeviceModelsRepository.CLI.SmokeTests.ResolveRemote": {
       "commandName": "Project",
       "commandLineArgs": "export --dtmi dtmi:com:example:Thermostat;1"
     },
-    "Azure.DigitalTwins.Resolver.CLI.SmokeTests.ShowLocal": {
+    "Azure.IoT.DeviceModelsRepository.CLI.SmokeTests.ResolveLocal": {
       "commandName": "Project",
       "commandLineArgs": "export --dtmi dtmi:com:example:Thermostat;1 --repository ../../../../Azure.IoT.DeviceModelsRepository.Resolver.Tests/TestModelRepo/"
     },
-    "Azure.DigitalTwins.Resolver.CLI.SmokeTests.ResolveBasic": {
-      "commandName": "Project",
-      "commandLineArgs": "export --dtmi dtmi:com:example:Thermostat;1"
-    },
-    "Azure.DigitalTwins.Resolver.CLI.SmokeTests.ResolveBasicSilent": {
+    "Azure.IoT.DeviceModelsRepository.CLI.SmokeTests.ResolveBasicSilent": {
       "commandName": "Project",
       "commandLineArgs": "export --dtmi dtmi:com:example:TemperatureController;1 --silent"
     },
-    "Azure.DigitalTwins.Resolver.CLI.SmokeTests.ResolveBasicOutFile1": {
+    "Azure.IoT.DeviceModelsRepository.CLI.SmokeTests.ResolveBasicOutFile1": {
       "commandName": "Project",
       "commandLineArgs": "export --dtmi dtmi:com:example:Thermostat;1 -o mytestmodel.json"
     },
-    "Azure.DigitalTwins.Resolver.CLI.SmokeTests.ResolveBasicOutFile2": {
+    "Azure.IoT.DeviceModelsRepository.CLI.SmokeTests.ResolveBasicOutFile2": {
       "commandName": "Project",
       "commandLineArgs": "export --dtmi dtmi:com:example:TemperatureController;1 -o mytestmodel.json"
     },
-    "Azure.DigitalTwins.Resolver.CLI.SmokeTests.ResolveFail": {
+    "Azure.IoT.DeviceModelsRepository.CLI.SmokeTests.ResolveFail": {
       "commandName": "Project",
       "commandLineArgs": "export --dtmi dtmi:com:example:Thermojax;999"
     },
-    "Azure.DigitalTwins.Resolver.CLI.SmokeTests.ResolveFromFile": {
+    "Azure.IoT.DeviceModelsRepository.CLI.SmokeTests.ResolveFromFile": {
       "commandName": "Project",
       "commandLineArgs": "export --model-file ../../../../Azure.IoT.DeviceModelsRepository.Resolver.Tests/TestModelRepo/dtmi/com/example/temperaturecontroller-1.json --repository ../../../../Azure.IoT.DeviceModelsRepository.Resolver.Tests/TestModelRepo/ -o mytestmodel.expanded.json"
     },
-    "Azure.DigitalTwins.Resolver.CLI.SmokeTests.ResolveFromFileFail": {
+    "Azure.IoT.DeviceModelsRepository.CLI.SmokeTests.ResolveFromFileFail": {
       "commandName": "Project",
       "commandLineArgs": "export --repository ../../../../Azure.IoT.DeviceModelsRepository.Resolver.Tests/TestModelRepo/ -o mytestmodel.expanded.json"
     },
-    "Azure.DigitalTwins.Resolver.CLI.SmokeTests.ValidateBasic": {
+    "Azure.IoT.DeviceModelsRepository.CLI.SmokeTests.ValidateBasic": {
       "commandName": "Project",
       "commandLineArgs": "validate --model-file ../../../../Azure.IoT.DeviceModelsRepository.Resolver.Tests/TestModelRepo/dtmi/com/example/thermostat-1.json"
     },
-    "Azure.DigitalTwins.Resolver.CLI.SmokeTests.ValidateFail1": {
+    "Azure.IoT.DeviceModelsRepository.CLI.SmokeTests.ValidateFail1": {
       "commandName": "Project",
       "commandLineArgs": "validate --model-file ../../../../Azure.IoT.DeviceModelsRepository.Resolver.Tests/TestModelRepo/dtmi/com/example/invalidmodel-1.json"
     },
-    "Azure.DigitalTwins.Resolver.CLI.SmokeTests.ValidateFail2": {
+    "Azure.IoT.DeviceModelsRepository.CLI.SmokeTests.ValidateFail2": {
       "commandName": "Project",
       "commandLineArgs": "validate --model-file ../../../../Azure.IoT.DeviceModelsRepository.Resolver.Tests/TestModelRepo/dtmi/com/example/invalidmodel-2.json"
     },
-    "Azure.DigitalTwins.Resolver.CLI.AddModel" : {
+    "Azure.IoT.DeviceModelsRepository.CLI.AddModel": {
       "commandName": "Project",
       "commandLineArgs": "import --model-file ../../../../Azure.IoT.DeviceModelsRepository.Resolver.Tests/TestModelRepo/dtmi/com/example/thermostat-1.json --repository ../../../../../../.localRepository/ --force"
     },
-    "Azure.DigitalTwins.Resolver.CLI.AddModelInvalid" : {
+    "Azure.IoT.DeviceModelsRepository.CLI.AddModelInvalid": {
       "commandName": "Project",
       "commandLineArgs": "import --model-file ../../../../Azure.IoT.DeviceModelsRepository.Resolver.Tests/TestModelRepo/dtmi/com/example/invalidmodel-2.json --repository ../../../../../../.localRepository/ --force"
     }

--- a/resolvers/dotnet/Azure.IoT.DeviceModelsRepository.CLI/Validations.cs
+++ b/resolvers/dotnet/Azure.IoT.DeviceModelsRepository.CLI/Validations.cs
@@ -116,5 +116,12 @@ namespace Azure.IoT.DeviceModelsRepository.CLI
             var versionRegex = new Regex(";[1-9][0-9]{0,8}$");
             return versionRegex.Replace(id.GetString(), "");
         }
+
+        public static bool IsRelativePath(string repositoryPath)
+        {
+            Uri testUri;
+            bool validUri = Uri.TryCreate(repositoryPath, UriKind.Relative, out testUri);
+            return validUri && testUri != null;
+        }
     }
 }

--- a/resolvers/dotnet/Azure.IoT.DeviceModelsRepository.Resolver.Extensions/Azure.IoT.DeviceModelsRepository.Resolver.Extensions.csproj
+++ b/resolvers/dotnet/Azure.IoT.DeviceModelsRepository.Resolver.Extensions/Azure.IoT.DeviceModelsRepository.Resolver.Extensions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Version>0.0.1</Version>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Authors>Microsoft</Authors>

--- a/resolvers/dotnet/Azure.IoT.DeviceModelsRepository.Resolver.Tests/Azure.IoT.DeviceModelsRepository.Resolver.Tests.csproj
+++ b/resolvers/dotnet/Azure.IoT.DeviceModelsRepository.Resolver.Tests/Azure.IoT.DeviceModelsRepository.Resolver.Tests.csproj
@@ -13,10 +13,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.DigitalTwins.Parser" Version="3.12.5" />
-    <PackageReference Include="Moq" Version="4.14.5" />
+    <PackageReference Include="Moq" Version="4.14.7" />
     <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/resolvers/dotnet/Azure.IoT.DeviceModelsRepository.Resolver.Tests/ClientTests.cs
+++ b/resolvers/dotnet/Azure.IoT.DeviceModelsRepository.Resolver.Tests/ClientTests.cs
@@ -109,10 +109,10 @@ namespace Azure.IoT.DeviceModelsRepository.Resolver.Tests
             Uri repositoryUri = new Uri(repositoryUriString);
 
             ResolverClient defaultClient = new ResolverClient(repositoryUri);
-            Assert.AreEqual(defaultClient.Settings.DependencyResolution, defaultResolutionOption);
+            Assert.AreEqual(defaultClient.ClientOptions.DependencyResolution, defaultResolutionOption);
 
             ResolverClient customClient = new ResolverClient(repositoryUriString, customOptions);
-            Assert.AreEqual(customClient.Settings.DependencyResolution, DependencyResolutionOption.FromExpanded);
+            Assert.AreEqual(customClient.ClientOptions.DependencyResolution, DependencyResolutionOption.FromExpanded);
         }
     }
 }

--- a/resolvers/dotnet/Azure.IoT.DeviceModelsRepository.Resolver.Tests/ClientTests.cs
+++ b/resolvers/dotnet/Azure.IoT.DeviceModelsRepository.Resolver.Tests/ClientTests.cs
@@ -8,64 +8,58 @@ namespace Azure.IoT.DeviceModelsRepository.Resolver.Tests
 {
     public class ClientTests
     {
-        Mock<ILogger> _logger;
-
-        [SetUp]
-        public void Setup()
+        [Test]
+        public void ClientInitRemoteRepository()
         {
-            _logger = new Mock<ILogger>();
+            Mock<ILogger> fromUriLogger = new Mock<ILogger>();
+            Mock<ILogger> fromStrLogger = new Mock<ILogger>();
+
+            string remoteRepoEndpoint = "https://localhost/repository";
+            Uri repositoryUri = new Uri(remoteRepoEndpoint);
+
+            ResolverClient clientInitUri = new ResolverClient(repositoryUri, default, fromUriLogger.Object);
+            ResolverClient clientInitStr = new ResolverClient(remoteRepoEndpoint, default, logger: fromStrLogger.Object);
+
+            Assert.AreEqual(repositoryUri, clientInitUri.RepositoryUri);
+            Assert.AreEqual(remoteRepoEndpoint, clientInitUri.RepositoryUri.AbsoluteUri);
+
+            fromUriLogger.ValidateLog(StandardStrings.ClientInitWithFetcher(repositoryUri.Scheme), LogLevel.Trace, Times.Once());
+
+            Assert.AreEqual(repositoryUri, clientInitStr.RepositoryUri);
+            Assert.AreEqual(remoteRepoEndpoint, clientInitStr.RepositoryUri.AbsoluteUri);
+
+            fromStrLogger.ValidateLog(StandardStrings.ClientInitWithFetcher(repositoryUri.Scheme), LogLevel.Trace, Times.Once());
+
+            ResolverClient clientInitDefault = new ResolverClient();
+            Assert.AreEqual($"{ResolverClient.DefaultRepository}/", clientInitDefault.RepositoryUri.AbsoluteUri);
         }
 
         [Test]
-        public void ClientInitGenericRepoUri()
+        public void ClientInitLocalRepository()
         {
-            string registryUriString = "https://localhost/myregistry/";
-            Uri registryUri = new Uri(registryUriString);
+            Mock<ILogger> fromUriLogger = new Mock<ILogger>();
+            Mock<ILogger> fromStrLogger = new Mock<ILogger>();
 
-            // Uses NullLogger
-            ResolverClient client = new ResolverClient(registryUri);
-            Assert.AreEqual(registryUri, client.RepositoryUri);
+            string localTestRepoPath = TestHelpers.TestLocalModelRepository;
+            Uri repositoryUri = new Uri($"file://{localTestRepoPath}");
 
-            client = new ResolverClient(registryUri, _logger.Object);
-            Assert.AreEqual(registryUri, client.RepositoryUri);
-            _logger.ValidateLog(StandardStrings.ClientInitWithFetcher(registryUri.Scheme), LogLevel.Trace, Times.Once());
-        }
-
-        [Test]
-        public void ClientInitRemoteRepoHelper()
-        {
-            string registryUriString = "https://localhost/myregistry/";
-            Uri registryUri = new Uri(registryUriString);
-
-            ResolverClient client = ResolverClient.FromRemoteRepository(registryUriString);
-            Assert.AreEqual(registryUri, client.RepositoryUri);
-
-            client = ResolverClient.FromRemoteRepository(registryUriString, _logger.Object);
-            Assert.AreEqual(registryUri, client.RepositoryUri);
-            _logger.ValidateLog(StandardStrings.ClientInitWithFetcher(registryUri.Scheme), LogLevel.Trace, Times.Once());
-        }
-
-        [Test]
-        public void ClientInitLocalRepoHelper()
-        {
-            string testModelRegistryPath = TestHelpers.GetTestLocalModelRepository();
-            Uri registryUri = new Uri($"file://{testModelRegistryPath}");
-
-            // Uses NullLogger
-            ResolverClient client = ResolverClient.FromLocalRepository(testModelRegistryPath);
+            ResolverClient clientInitUri = new ResolverClient(repositoryUri, default, fromUriLogger.Object) ;
+            ResolverClient clientInitStr = new ResolverClient(localTestRepoPath, default, logger: fromStrLogger.Object);
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                testModelRegistryPath = testModelRegistryPath.Replace("\\", "/");
+                localTestRepoPath = localTestRepoPath.Replace("\\", "/");
             }
 
-            Assert.AreEqual(registryUri, client.RepositoryUri);
-            Assert.AreEqual(testModelRegistryPath, client.RepositoryUri.AbsolutePath);
+            Assert.AreEqual(repositoryUri, clientInitUri.RepositoryUri);
+            Assert.AreEqual(localTestRepoPath, clientInitUri.RepositoryUri.AbsolutePath);
 
-            client = ResolverClient.FromLocalRepository(testModelRegistryPath, _logger.Object);
-            Assert.AreEqual(registryUri, client.RepositoryUri);
+            fromUriLogger.ValidateLog(StandardStrings.ClientInitWithFetcher(repositoryUri.Scheme), LogLevel.Trace, Times.Once());
 
-            _logger.ValidateLog(StandardStrings.ClientInitWithFetcher(registryUri.Scheme), LogLevel.Trace, Times.Once());
+            Assert.AreEqual(repositoryUri, clientInitStr.RepositoryUri);
+            Assert.AreEqual(localTestRepoPath, clientInitStr.RepositoryUri.AbsolutePath);
+
+            fromStrLogger.ValidateLog(StandardStrings.ClientInitWithFetcher(repositoryUri.Scheme), LogLevel.Trace, Times.Once());
         }
 
         [TestCase("dtmi:com:example:Thermostat;1", true)]
@@ -78,36 +72,20 @@ namespace Azure.IoT.DeviceModelsRepository.Resolver.Tests
             Assert.AreEqual(ResolverClient.IsValidDtmi(dtmi), expected);
         }
 
-        [TestCase("dtmi:com:example:Thermostat;1", "/dtmi/com/example/thermostat-1.json")]
-        [TestCase("dtmi:com:example:Thermostat:1", null)]
-        public void ClientLocalRepoGetPath(string dtmi, string expectedPath)
+        [TestCase("dtmi:com:example:Thermostat;1", "/dtmi/com/example/thermostat-1.json", "https://localhost/repository")]
+        [TestCase("dtmi:com:example:Thermostat;1", "/dtmi/com/example/thermostat-1.json", null)]
+        [TestCase("dtmi:com:example:Thermostat:1", null, "https://localhost/repository")]
+        public void ClientGetPath(string dtmi, string expectedPath, string repository)
         {
-            string testModelRegistryPath = TestHelpers.GetTestLocalModelRepository();
-            ResolverClient client = ResolverClient.FromLocalRepository(testModelRegistryPath);
+            if (repository == null)
+                repository = TestHelpers.TestLocalModelRepository;
 
-            if (string.IsNullOrEmpty(expectedPath))
-            {
-                ResolverException re = Assert.Throws<ResolverException>(() => client.GetPath(dtmi));
-                Assert.AreEqual(re.Message, $"{StandardStrings.GenericResolverError(dtmi)}{StandardStrings.InvalidDtmiFormat(dtmi)}");
-                return;
-            }
-
-            string modelPath = client.GetPath(dtmi);
+            ResolverClient client = new ResolverClient(repository);
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                testModelRegistryPath = testModelRegistryPath.Replace("\\", "/");
+                repository = repository.Replace("\\", "/");
             }
-
-            Assert.AreEqual(modelPath, $"{testModelRegistryPath}{expectedPath}");
-        }
-
-        [TestCase("dtmi:com:example:Thermostat;1", "/dtmi/com/example/thermostat-1.json")]
-        [TestCase("dtmi:com:example:Thermostat:1", null)]
-        public void ClientRemoteRepoGetPath(string dtmi, string expectedPath)
-        {
-            string registryUriString = "https://localhost/myregistry";
-            ResolverClient client = ResolverClient.FromRemoteRepository(registryUriString);
 
             if (string.IsNullOrEmpty(expectedPath))
             {
@@ -117,23 +95,23 @@ namespace Azure.IoT.DeviceModelsRepository.Resolver.Tests
             }
 
             string modelPath = client.GetPath(dtmi);
-            Assert.AreEqual(modelPath, $"{registryUriString}{expectedPath}");
+            Assert.AreEqual(modelPath, $"{repository}{expectedPath}");
         }
 
         [Test]
-        public void ClientSettings()
+        public void ClientOptions()
         {
             DependencyResolutionOption defaultResolutionOption = DependencyResolutionOption.Enabled;
-            ResolverClientSettings customSettings = 
-                new ResolverClientSettings(DependencyResolutionOption.FromExpanded);
+            ResolverClientOptions customOptions = 
+                new ResolverClientOptions(DependencyResolutionOption.FromExpanded);
 
-            string registryUriString = "https://localhost/myregistry/";
-            Uri registryUri = new Uri(registryUriString);
+            string repositoryUriString = "https://localhost/myregistry/";
+            Uri repositoryUri = new Uri(repositoryUriString);
 
-            ResolverClient defaultClient = new ResolverClient(registryUri);
+            ResolverClient defaultClient = new ResolverClient(repositoryUri);
             Assert.AreEqual(defaultClient.Settings.DependencyResolution, defaultResolutionOption);
 
-            ResolverClient customClient = new ResolverClient(registryUri, settings: customSettings);
+            ResolverClient customClient = new ResolverClient(repositoryUriString, customOptions);
             Assert.AreEqual(customClient.Settings.DependencyResolution, DependencyResolutionOption.FromExpanded);
         }
     }

--- a/resolvers/dotnet/Azure.IoT.DeviceModelsRepository.Resolver.Tests/FetchIntegrationTests.cs
+++ b/resolvers/dotnet/Azure.IoT.DeviceModelsRepository.Resolver.Tests/FetchIntegrationTests.cs
@@ -11,8 +11,8 @@ namespace Azure.IoT.DeviceModelsRepository.Resolver.Tests
 {
     public class FetchIntegrationTests
     {
-        readonly Uri _remoteUri = new Uri(TestHelpers.GetTestRemoteModelRepository());
-        readonly Uri _localUri = new Uri($"file://{TestHelpers.GetTestLocalModelRepository()}");
+        readonly Uri _remoteUri = new Uri(TestHelpers.TestRemoteModelRepository);
+        readonly Uri _localUri = new Uri($"file://{TestHelpers.TestLocalModelRepository}");
         Mock<ILogger> _logger;
         IModelFetcher _localFetcher;
         IModelFetcher _remoteFetcher;

--- a/resolvers/dotnet/Azure.IoT.DeviceModelsRepository.Resolver.Tests/ModelQueryTests.cs
+++ b/resolvers/dotnet/Azure.IoT.DeviceModelsRepository.Resolver.Tests/ModelQueryTests.cs
@@ -63,7 +63,7 @@ namespace Azure.IoT.DeviceModelsRepository.Resolver.Tests
         [TestCase("", "")]
         public void GetComponentSchema(string contents, string expected)
         {
-            string[] expectedDtmis = expected.Split(",", System.StringSplitOptions.RemoveEmptyEntries);
+            string[] expectedDtmis = expected.Split(new[] { "," }, System.StringSplitOptions.RemoveEmptyEntries);
             string modelContent = string.Format(_modelTemplate, "", "", contents);
             ModelQuery query = new ModelQuery(modelContent);
             IList<string> componentSchemas = query.GetComponentSchemas();
@@ -83,7 +83,7 @@ namespace Azure.IoT.DeviceModelsRepository.Resolver.Tests
         [TestCase("", "")]
         public void GetExtends(string extends, string expected)
         {
-            string[] expectedDtmis = expected.Split(",", System.StringSplitOptions.RemoveEmptyEntries);
+            string[] expectedDtmis = expected.Split(new[] { "," }, System.StringSplitOptions.RemoveEmptyEntries);
             string modelContent = string.Format(_modelTemplate, "", extends, "");
             ModelQuery query = new ModelQuery(modelContent);
             IList<string> extendsDtmis = query.GetExtends();
@@ -118,7 +118,7 @@ namespace Azure.IoT.DeviceModelsRepository.Resolver.Tests
         )]
         public void GetModelDependencies(string id, string extends, string contents, string expected)
         {
-            string[] expectedDtmis = expected.Split(",", System.StringSplitOptions.RemoveEmptyEntries);
+            string[] expectedDtmis = expected.Split(new[] { "," }, System.StringSplitOptions.RemoveEmptyEntries);
             string modelContent = string.Format(_modelTemplate, id, extends, contents);
             ModelMetadata metadata = new ModelQuery(modelContent).GetMetadata();
 
@@ -135,8 +135,8 @@ namespace Azure.IoT.DeviceModelsRepository.Resolver.Tests
         [Test]
         public async Task ListToDictAsync()
         {
-            string testRepoPath = TestHelpers.GetTestLocalModelRepository();
-            string expandedContent = await File.ReadAllTextAsync(
+            string testRepoPath = TestHelpers.TestLocalModelRepository;
+            string expandedContent = File.ReadAllText(
                 $"{testRepoPath}/dtmi/com/example/temperaturecontroller-1.expanded.json", Encoding.UTF8);
             ModelQuery query = new ModelQuery(expandedContent);
             Dictionary<string, string> transformResult = await query.ListToDictAsync();

--- a/resolvers/dotnet/Azure.IoT.DeviceModelsRepository.Resolver.Tests/ParserIntegrationTests.cs
+++ b/resolvers/dotnet/Azure.IoT.DeviceModelsRepository.Resolver.Tests/ParserIntegrationTests.cs
@@ -14,7 +14,7 @@ namespace Azure.IoT.DeviceModelsRepository.Resolver.Tests
         public async Task ParserValidationResolveFromLocalRepository()
         {
             ModelParser parser = new ModelParser();
-            string TestRegistryPath = TestHelpers.GetTestLocalModelRepository();
+            string TestRegistryPath = TestHelpers.TestLocalModelRepository;
 
             List<string> parseModelPaths = new List<string>()
             {
@@ -24,7 +24,7 @@ namespace Azure.IoT.DeviceModelsRepository.Resolver.Tests
             };
 
             // Shows how to quickly integrate the resolver client with the parser.
-            ResolverClient client = ResolverClient.FromLocalRepository(TestRegistryPath);
+            ResolverClient client = new ResolverClient(TestRegistryPath);
             parser.DtmiResolver = client.ParserDtmiResolver;
 
             foreach(string modelPath in parseModelPaths) {
@@ -43,13 +43,13 @@ namespace Azure.IoT.DeviceModelsRepository.Resolver.Tests
         public void ParserValidationResolveFromLocalRepoErrorOnParserCallbackDtmiCasing()
         {
             ModelParser parser = new ModelParser();
-            string TestRegistryPath = TestHelpers.GetTestLocalModelRepository();
+            string TestRegistryPath = TestHelpers.TestLocalModelRepository;
 
             // This model references another model with invalid casing.
             string modelPath = $"{TestRegistryPath}/dtmi/company/demodevice-1.json";
 
             // Shows how to quickly integrate the resolver client with the parser.
-            ResolverClient client = ResolverClient.FromLocalRepository(TestRegistryPath);
+            ResolverClient client = new ResolverClient(TestRegistryPath);
             parser.DtmiResolver = client.ParserDtmiResolver;
 
             // Parser will throw on validation errors
@@ -68,11 +68,11 @@ namespace Azure.IoT.DeviceModelsRepository.Resolver.Tests
             ModelParser parser = new ModelParser();
 
             // TODO: One off model -- need consistent remote model repo for IT's
-            string TestRepoPath = TestHelpers.GetTestLocalModelRepository();
+            string TestRepoPath = TestHelpers.TestLocalModelRepository;
             string testModelPath = $"{TestRepoPath}/dtmi/company/demodevice-2.json";
 
             // Shows how to quickly integrate the resolver client with the parser.
-            ResolverClient client = ResolverClient.FromRemoteRepository(TestHelpers.GetTestRemoteModelRepository());
+            ResolverClient client = new ResolverClient(TestHelpers.TestRemoteModelRepository);
             parser.DtmiResolver = client.ParserDtmiResolver;
 
             // Parser will throw on validation errors

--- a/resolvers/dotnet/Azure.IoT.DeviceModelsRepository.Resolver.Tests/ResolveIntegrationTests.cs
+++ b/resolvers/dotnet/Azure.IoT.DeviceModelsRepository.Resolver.Tests/ResolveIntegrationTests.cs
@@ -17,7 +17,7 @@ namespace Azure.IoT.DeviceModelsRepository.Resolver.Tests
         [SetUp]
         public void Setup()
         {
-            _localClient = ResolverClient.FromLocalRepository(TestHelpers.GetTestLocalModelRepository());
+            _localClient = new ResolverClient(TestHelpers.TestLocalModelRepository);
 
             // TODO: Needs consistent remote repo
             // _remoteClient = ResolverClient.FromRemoteRepository(TestHelpers.GetTestRemoteModelRegistry());
@@ -81,10 +81,10 @@ namespace Azure.IoT.DeviceModelsRepository.Resolver.Tests
         public async Task ResolveSingleModelWithDepsAndLogger(string dtmi, string expectedDeps)
         {
             Mock<ILogger> _logger = new Mock<ILogger>();
-            ResolverClient localClient = ResolverClient.FromLocalRepository(TestHelpers.GetTestLocalModelRepository(), _logger.Object);
+            ResolverClient localClient = new ResolverClient(TestHelpers.TestLocalModelRepository, default, _logger.Object);
 
             var result = await localClient.ResolveAsync(dtmi);
-            var expectedDtmis = $"{dtmi},{expectedDeps}".Split(',', StringSplitOptions.RemoveEmptyEntries);
+            var expectedDtmis = $"{dtmi},{expectedDeps}".Split(new[] { "," }, StringSplitOptions.RemoveEmptyEntries);
 
             Assert.True(result.Keys.Count == expectedDtmis.Length);
             foreach (var id in expectedDtmis)
@@ -117,8 +117,8 @@ namespace Azure.IoT.DeviceModelsRepository.Resolver.Tests
                   "dtmi:com:example:Camera;3")]
         public async Task ResolveMultipleModelsWithDeps(string dtmi1, string dtmi2, string expectedDeps)
         {
-            var result = await _localClient.ResolveAsync(dtmi1, dtmi2);
-            var expectedDtmis = $"{dtmi1},{dtmi2},{expectedDeps}".Split(',', StringSplitOptions.RemoveEmptyEntries);
+            var result = await _localClient.ResolveAsync(new[] { dtmi1, dtmi2 });
+            var expectedDtmis = $"{dtmi1},{dtmi2},{expectedDeps}".Split(new[] { "," }, StringSplitOptions.RemoveEmptyEntries);
 
             Assert.True(result.Keys.Count == expectedDtmis.Length);
             foreach (var id in expectedDtmis)
@@ -133,8 +133,8 @@ namespace Azure.IoT.DeviceModelsRepository.Resolver.Tests
                   "dtmi:com:example:Thermostat;1,dtmi:azure:DeviceManagement:DeviceInformation;1,dtmi:com:example:Room;1")]
         public async Task ResolveMultipleModelsWithDepsFromExtends(string dtmi1, string dtmi2, string expectedDeps)
         {
-            var result = await _localClient.ResolveAsync(dtmi1, dtmi2); // Uses ResolveAsync(params string[])
-            var expectedDtmis = $"{dtmi1},{dtmi2},{expectedDeps}".Split(',', StringSplitOptions.RemoveEmptyEntries);
+            var result = await _localClient.ResolveAsync(new[] { dtmi1, dtmi2 });
+            var expectedDtmis = $"{dtmi1},{dtmi2},{expectedDeps}".Split(new[] { "," }, StringSplitOptions.RemoveEmptyEntries);
 
             Assert.True(result.Keys.Count == expectedDtmis.Length);
             foreach (var id in expectedDtmis)
@@ -150,10 +150,36 @@ namespace Azure.IoT.DeviceModelsRepository.Resolver.Tests
                   "dtmi:azure:DeviceManagement:DeviceInformation;1," +
                   "dtmi:com:example:Room;1," +
                   "dtmi:com:example:Freezer;1")]
-        public async Task ResolveMultipleModelsWithDepsFromExtendsVarient(string dtmi1, string dtmi2, string expectedDeps)
+        public async Task ResolveMultipleModelsWithDepsFromExtendsVariant(string dtmi1, string dtmi2, string expectedDeps)
         {
-            var result = await _localClient.ResolveAsync(dtmi1, dtmi2); // Uses ResolveAsync(params string[])
-            var expectedDtmis = $"{dtmi1},{dtmi2},{expectedDeps}".Split(',', StringSplitOptions.RemoveEmptyEntries);
+            var result = await _localClient.ResolveAsync(new[] { dtmi1, dtmi2 });
+            var expectedDtmis = $"{dtmi1},{dtmi2},{expectedDeps}".Split(new[] { "," }, StringSplitOptions.RemoveEmptyEntries);
+
+            Assert.True(result.Keys.Count == expectedDtmis.Length);
+            foreach (var id in expectedDtmis)
+            {
+                Assert.True(result.ContainsKey(id));
+                Assert.True(TestHelpers.ParseRootDtmiFromJson(result[id]) == id);
+            }
+        }
+
+        [TestCase("dtmi:com:example:base;1")]
+        public async Task ResolveModelWithDepsFromExtendsInline(string dtmi)
+        {
+            var result = await _localClient.ResolveAsync(dtmi);
+
+            Assert.True(result.Keys.Count == 1);
+            Assert.True(result.ContainsKey(dtmi));
+            Assert.True(TestHelpers.ParseRootDtmiFromJson(result[dtmi]) == dtmi);
+        }
+
+        [TestCase("dtmi:com:example:base;2",
+                  "dtmi:com:example:Freezer;1," +
+                  "dtmi:com:example:Thermostat;1")]
+        public async Task ResolveModelWithDepsFromExtendsInlineVariant(string dtmi, string expected)
+        {
+            var result = await _localClient.ResolveAsync(dtmi);
+            var expectedDtmis = $"{dtmi},{expected}".Split(new[] { "," }, StringSplitOptions.RemoveEmptyEntries);
 
             Assert.True(result.Keys.Count == expectedDtmis.Length);
             foreach (var id in expectedDtmis)
@@ -166,7 +192,7 @@ namespace Azure.IoT.DeviceModelsRepository.Resolver.Tests
         [TestCase("dtmi:azure:DeviceManagement:DeviceInformation;1", "dtmi:azure:DeviceManagement:DeviceInformation;1")]
         public async Task ResolveEnsureNoDupes(string dtmiDupe1, string dtmiDupe2)
         {
-            var result = await _localClient.ResolveAsync(dtmiDupe1, dtmiDupe2);
+            var result = await _localClient.ResolveAsync(new[] { dtmiDupe1, dtmiDupe2 });
             Assert.True(result.Keys.Count == 1);
             Assert.True(TestHelpers.ParseRootDtmiFromJson(result[dtmiDupe1]) == dtmiDupe1);
         }
@@ -174,9 +200,9 @@ namespace Azure.IoT.DeviceModelsRepository.Resolver.Tests
         [TestCase("dtmi:com:example:TemperatureController;1")]
         public async Task ResolveSingleModelWithDepsDisableDependencyResolution(string dtmi)
         {
-            ResolverClientSettings settings = new ResolverClientSettings(DependencyResolutionOption.Disabled);
-            ResolverClient localClient = ResolverClient.FromLocalRepository(
-                TestHelpers.GetTestLocalModelRepository(), settings: settings);
+            ResolverClientOptions options = new ResolverClientOptions(DependencyResolutionOption.Disabled);
+            ResolverClient localClient = new ResolverClient(
+                TestHelpers.TestLocalModelRepository, options: options);
 
             var result = await localClient.ResolveAsync(dtmi);
 
@@ -196,22 +222,22 @@ namespace Azure.IoT.DeviceModelsRepository.Resolver.Tests
         public async Task ResolveUseExpanded(string dtmi, string expectedDeps, RepositoryHandler.RepositoryTypeCategory clientType)
         {
             Mock<ILogger> _logger = new Mock<ILogger>();
-            var expectedDtmis = $"{dtmi},{expectedDeps}".Split(',', StringSplitOptions.RemoveEmptyEntries);
+            var expectedDtmis = $"{dtmi},{expectedDeps}".Split(new[] { "," }, StringSplitOptions.RemoveEmptyEntries);
 
-            ResolverClientSettings settings = new ResolverClientSettings(DependencyResolutionOption.FromExpanded);
+            ResolverClientOptions options = new ResolverClientOptions(DependencyResolutionOption.FromExpanded);
 
             ResolverClient client = null;
             if (clientType == RepositoryHandler.RepositoryTypeCategory.LocalUri)
-                client = ResolverClient.FromLocalRepository(
-                    TestHelpers.GetTestLocalModelRepository(),
-                    settings: settings,
-                    logger: _logger.Object);
+                client = new ResolverClient(
+                    TestHelpers.TestLocalModelRepository,
+                    options,
+                    _logger.Object);
 
             if (clientType == RepositoryHandler.RepositoryTypeCategory.RemoteUri)
-                client = ResolverClient.FromRemoteRepository(
-                    TestHelpers.GetTestRemoteModelRepository(),
-                    settings: settings,
-                    logger: _logger.Object);
+                client = new ResolverClient(
+                    TestHelpers.TestRemoteModelRepository,
+                    options,
+                    _logger.Object);
 
             var result = await client.ResolveAsync(dtmi);
 
@@ -238,19 +264,19 @@ namespace Azure.IoT.DeviceModelsRepository.Resolver.Tests
         public async Task ResolveUseExpandedPartialMultipleDtmi(string dtmisExpanded, string dtmisNonExpanded)
         {
             Mock<ILogger> _logger = new Mock<ILogger>();
-            string[] expandedDtmis = dtmisExpanded.Split(',', StringSplitOptions.RemoveEmptyEntries);
-            string[] nonExpandedDtmis = dtmisNonExpanded.Split(',', StringSplitOptions.RemoveEmptyEntries);
+            string[] expandedDtmis = dtmisExpanded.Split(new[] { "," }, StringSplitOptions.RemoveEmptyEntries);
+            string[] nonExpandedDtmis = dtmisNonExpanded.Split(new[] { "," }, StringSplitOptions.RemoveEmptyEntries);
             string[] totalDtmis = expandedDtmis.Concat(nonExpandedDtmis).ToArray();
 
-            ResolverClientSettings settings = new ResolverClientSettings(DependencyResolutionOption.FromExpanded);
+            ResolverClientOptions options = new ResolverClientOptions(DependencyResolutionOption.FromExpanded);
 
-            ResolverClient localClient = ResolverClient.FromLocalRepository(
-                TestHelpers.GetTestLocalModelRepository(),
-                settings: settings,
+            ResolverClient localClient = new ResolverClient(
+                TestHelpers.TestLocalModelRepository,
+                options: options,
                 logger: _logger.Object);
 
             // Multi-resolve dtmi:com:example:TemperatureController;1 + dtmi:com:example:ColdStorage;1
-            var result = await localClient.ResolveAsync(expandedDtmis[0], nonExpandedDtmis[0]);
+            var result = await localClient.ResolveAsync(new[] { expandedDtmis[0], nonExpandedDtmis[0] });
 
             Assert.True(result.Keys.Count == totalDtmis.Length);
             foreach (string id in totalDtmis)

--- a/resolvers/dotnet/Azure.IoT.DeviceModelsRepository.Resolver.Tests/TestHelpers.cs
+++ b/resolvers/dotnet/Azure.IoT.DeviceModelsRepository.Resolver.Tests/TestHelpers.cs
@@ -1,7 +1,6 @@
 ﻿using NUnit.Framework;
 using System;
 using System.IO;
-using System.Linq;
 using System.Text.Json;
 
 namespace Azure.IoT.DeviceModelsRepository.Resolver.Tests
@@ -17,24 +16,18 @@ namespace Azure.IoT.DeviceModelsRepository.Resolver.Tests
                 AllowTrailingCommas = true
             };
 
-            using JsonDocument document = JsonDocument.Parse(json, options);
-            var dtmi = document.RootElement.EnumerateObject().Single(x => x.Name == "@id").Value.GetString();
+            string dtmi = string.Empty;
+            using (JsonDocument document = JsonDocument.Parse(json, options))
+            {
+                dtmi = document.RootElement.GetProperty("@id").GetString();
+            }
             return dtmi;
         }
 
-        public static string GetTestDirectoryPath()
-        {
-            return Path.GetDirectoryName(Path.GetDirectoryName(Path.GetDirectoryName(TestContext.CurrentContext.TestDirectory)));
-        }
+        public static string TestDirectoryPath => Path.GetDirectoryName(Path.GetDirectoryName(Path.GetDirectoryName(TestContext.CurrentContext.TestDirectory)));
 
-        public static string GetTestLocalModelRepository()
-        {
-            return Path.Combine(GetTestDirectoryPath(), "TestModelRepo");
-        }
+        public static string TestLocalModelRepository => Path.Combine(TestDirectoryPath, "TestModelRepo");
 
-        public static string GetTestRemoteModelRepository()
-        {
-            return Environment.GetEnvironmentVariable("PNP_TEST_REMOTE_REPO") ?? _fallbackTestRemoteRepo;
-        }
+        public static string TestRemoteModelRepository => Environment.GetEnvironmentVariable("PNP_TEST_REMOTE_REPO") ?? _fallbackTestRemoteRepo;
     }
 }

--- a/resolvers/dotnet/Azure.IoT.DeviceModelsRepository.Resolver.Tests/TestModelRepo/dtmi/com/example/base-1.json
+++ b/resolvers/dotnet/Azure.IoT.DeviceModelsRepository.Resolver.Tests/TestModelRepo/dtmi/com/example/base-1.json
@@ -1,0 +1,56 @@
+﻿{
+  "@id": "dtmi:com:example:base;1",
+  "@type": "Interface",
+  "contents": [
+    {
+      "@type": "Property",
+      "name": "baseSerialNumber",
+      "schema": "string"
+    }
+  ],
+  "displayName": {
+    "en": "mybaseProp"
+  },
+  "extends": [
+    {
+      "@id": "dtmi:com:example:basic;1",
+      "@type": "Interface",
+      "contents": [
+        {
+          "@type": "Property",
+          "name": "serialNumber",
+          "schema": "string",
+          "writable": false
+        },
+        {
+          "@type": [
+            "Telemetry",
+            "Temperature"
+          ],
+          "displayName": {
+            "en": "temperature"
+          },
+          "name": "temperature",
+          "schema": "double",
+          "unit": "degreeCelsius"
+        },
+        {
+          "@type": "Property",
+          "displayName": {
+            "en": "targetTemperature"
+          },
+          "name": "targetTemperature",
+          "schema": "double",
+          "writable": true
+        }
+      ],
+      "displayName": {
+        "en": "Basic"
+      }
+    }
+  ],
+  "@context": [
+    "dtmi:iotcentral:context;2",
+    "dtmi:dtdl:context;2"
+  ]
+}

--- a/resolvers/dotnet/Azure.IoT.DeviceModelsRepository.Resolver.Tests/TestModelRepo/dtmi/com/example/base-2.json
+++ b/resolvers/dotnet/Azure.IoT.DeviceModelsRepository.Resolver.Tests/TestModelRepo/dtmi/com/example/base-2.json
@@ -1,0 +1,57 @@
+﻿{
+  "@id": "dtmi:com:example:base;2",
+  "@type": "Interface",
+  "contents": [
+    {
+      "@type": "Property",
+      "name": "baseSerialNumber",
+      "schema": "string"
+    }
+  ],
+  "displayName": {
+    "en": "mybaseProp"
+  },
+  "extends": [
+    {
+      "@id": "dtmi:com:example:basic;1",
+      "@type": "Interface",
+      "contents": [
+        {
+          "@type": "Property",
+          "name": "serialNumber",
+          "schema": "string",
+          "writable": false
+        },
+        {
+          "@type": [
+            "Telemetry",
+            "Temperature"
+          ],
+          "displayName": {
+            "en": "temperature"
+          },
+          "name": "temperature",
+          "schema": "double",
+          "unit": "degreeCelsius"
+        },
+        {
+          "@type": "Property",
+          "displayName": {
+            "en": "targetTemperature"
+          },
+          "name": "targetTemperature",
+          "schema": "double",
+          "writable": true
+        }
+      ],
+      "displayName": {
+        "en": "Basic"
+      }
+    },
+    "dtmi:com:example:Freezer;1"
+  ],
+  "@context": [
+    "dtmi:iotcentral:context;2",
+    "dtmi:dtdl:context;2"
+  ]
+}

--- a/resolvers/dotnet/Azure.IoT.DeviceModelsRepository.Resolver/Azure.IoT.DeviceModelsRepository.Resolver.csproj
+++ b/resolvers/dotnet/Azure.IoT.DeviceModelsRepository.Resolver/Azure.IoT.DeviceModelsRepository.Resolver.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Version>0.0.10</Version>
     <Company>Microsoft</Company>
     <Authors>Microsoft</Authors>
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.8" />
+    <PackageReference Include="System.Text.Json" Version="4.7.2" />
   </ItemGroup>
 
 </Project>

--- a/resolvers/dotnet/Azure.IoT.DeviceModelsRepository.Resolver/Fetchers/LocalModelFetcher.cs
+++ b/resolvers/dotnet/Azure.IoT.DeviceModelsRepository.Resolver/Fetchers/LocalModelFetcher.cs
@@ -16,6 +16,7 @@ namespace Azure.IoT.DeviceModelsRepository.Resolver.Fetchers
             _logger = logger;
         }
 
+        // TODO: @digimaun - nothing Async is happening here due to the netstandard2.0 shift down.
         public async Task<FetchResult> FetchAsync(string dtmi, Uri registryUri, bool expanded = false)
         {
             string registryPath = registryUri.AbsolutePath;
@@ -44,7 +45,7 @@ namespace Azure.IoT.DeviceModelsRepository.Resolver.Fetchers
                 {
                     return new FetchResult()
                     {
-                        Definition = await File.ReadAllTextAsync(tryContentPath, Encoding.UTF8),
+                        Definition = File.ReadAllText(tryContentPath, Encoding.UTF8),
                         Path = tryContentPath
                     };
                 }

--- a/resolvers/dotnet/Azure.IoT.DeviceModelsRepository.Resolver/IResolverClient.cs
+++ b/resolvers/dotnet/Azure.IoT.DeviceModelsRepository.Resolver/IResolverClient.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Azure.IoT.DeviceModelsRepository.Resolver
+{
+    public interface IResolverClient
+    {
+        Task<IDictionary<string, string>> ResolveAsync(string dtmi);
+
+        Task<IDictionary<string, string>> ResolveAsync(IEnumerable<string> dtmis);
+    }
+}

--- a/resolvers/dotnet/Azure.IoT.DeviceModelsRepository.Resolver/ModelQuery.cs
+++ b/resolvers/dotnet/Azure.IoT.DeviceModelsRepository.Resolver/ModelQuery.cs
@@ -26,14 +26,16 @@ namespace Azure.IoT.DeviceModelsRepository.Resolver
 
         public string GetId()
         {
-            using JsonDocument document = JsonDocument.Parse(_content, _parseOptions);
-            JsonElement _root = document.RootElement;
-
-            if (_root.TryGetProperty("@id", out JsonElement id))
+            using (JsonDocument document = JsonDocument.Parse(_content, _parseOptions))
             {
-                if (id.ValueKind == JsonValueKind.String)
+                JsonElement _root = document.RootElement;
+
+                if (_root.TryGetProperty("@id", out JsonElement id))
                 {
-                    return id.GetString();
+                    if (id.ValueKind == JsonValueKind.String)
+                    {
+                        return id.GetString();
+                    }
                 }
             }
 
@@ -42,26 +44,28 @@ namespace Azure.IoT.DeviceModelsRepository.Resolver
 
         public IList<string> GetExtends()
         {
-            using JsonDocument document = JsonDocument.Parse(_content, _parseOptions);
-            JsonElement _root = document.RootElement;
-
             List<string> dependencies = new List<string>();
 
-            if (_root.TryGetProperty("extends", out JsonElement extends))
+            using (JsonDocument document = JsonDocument.Parse(_content, _parseOptions))
             {
-                if (extends.ValueKind == JsonValueKind.Array)
+                JsonElement _root = document.RootElement;
+
+                if (_root.TryGetProperty("extends", out JsonElement extends))
                 {
-                    foreach (JsonElement extendElement in extends.EnumerateArray())
+                    if (extends.ValueKind == JsonValueKind.Array)
                     {
-                        if (extendElement.ValueKind == JsonValueKind.String)
+                        foreach (JsonElement extendElement in extends.EnumerateArray())
                         {
-                            dependencies.Add(extendElement.GetString());
+                            if (extendElement.ValueKind == JsonValueKind.String)
+                            {
+                                dependencies.Add(extendElement.GetString());
+                            }
                         }
                     }
-                }
-                else if (extends.ValueKind == JsonValueKind.String)
-                {
-                    dependencies.Add(extends.GetString());
+                    else if (extends.ValueKind == JsonValueKind.String)
+                    {
+                        dependencies.Add(extends.GetString());
+                    }
                 }
             }
 
@@ -70,26 +74,28 @@ namespace Azure.IoT.DeviceModelsRepository.Resolver
 
         public IList<string> GetComponentSchemas()
         {
-            using JsonDocument document = JsonDocument.Parse(_content, _parseOptions);
-            JsonElement _root = document.RootElement;
-
             List<string> componentSchemas = new List<string>();
 
-            if (_root.TryGetProperty("contents", out JsonElement contents))
+            using (JsonDocument document = JsonDocument.Parse(_content, _parseOptions))
             {
-                if (contents.ValueKind == JsonValueKind.Array)
+                JsonElement _root = document.RootElement;
+
+                if (_root.TryGetProperty("contents", out JsonElement contents))
                 {
-                    foreach (JsonElement element in contents.EnumerateArray())
+                    if (contents.ValueKind == JsonValueKind.Array)
                     {
-                        if (element.TryGetProperty("@type", out JsonElement type))
+                        foreach (JsonElement element in contents.EnumerateArray())
                         {
-                            if (type.ValueKind == JsonValueKind.String && type.GetString() == "Component")
+                            if (element.TryGetProperty("@type", out JsonElement type))
                             {
-                                if (element.TryGetProperty("schema", out JsonElement schema))
+                                if (type.ValueKind == JsonValueKind.String && type.GetString() == "Component")
                                 {
-                                    if (schema.ValueKind == JsonValueKind.String)
+                                    if (element.TryGetProperty("schema", out JsonElement schema))
                                     {
-                                        componentSchemas.Add(schema.GetString());
+                                        if (schema.ValueKind == JsonValueKind.String)
+                                        {
+                                            componentSchemas.Add(schema.GetString());
+                                        }
                                     }
                                 }
                             }
@@ -104,24 +110,31 @@ namespace Azure.IoT.DeviceModelsRepository.Resolver
         public async Task<Dictionary<string, string>> ListToDictAsync()
         {
             Dictionary<string, string> result = new Dictionary<string, string>();
-            using JsonDocument document = JsonDocument.Parse(_content, _parseOptions);
-            JsonElement _root = document.RootElement;
 
-            if (_root.ValueKind == JsonValueKind.Array)
+            using (JsonDocument document = JsonDocument.Parse(_content, _parseOptions))
             {
-                foreach (JsonElement element in _root.EnumerateArray())
+                JsonElement _root = document.RootElement;
+
+                if (_root.ValueKind == JsonValueKind.Array)
                 {
-                    if (element.ValueKind == JsonValueKind.Object)
+                    foreach (JsonElement element in _root.EnumerateArray())
                     {
-                        using MemoryStream stream = new MemoryStream();
-                        await JsonSerializer.SerializeAsync(stream, element);
-                        stream.Position = 0;
+                        if (element.ValueKind == JsonValueKind.Object)
+                        {
+                            using (MemoryStream stream = new MemoryStream())
+                            {
+                                await JsonSerializer.SerializeAsync(stream, element);
+                                stream.Position = 0;
 
-                        using StreamReader streamReader = new StreamReader(stream);
-                        string serialized = await streamReader.ReadToEndAsync();
+                                using (StreamReader streamReader = new StreamReader(stream))
+                                {
+                                    string serialized = await streamReader.ReadToEndAsync();
 
-                        string id = new ModelQuery(serialized).GetId();
-                        result.Add(id, serialized);
+                                    string id = new ModelQuery(serialized).GetId();
+                                    result.Add(id, serialized);
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/resolvers/dotnet/Azure.IoT.DeviceModelsRepository.Resolver/RepositoryHandler.cs
+++ b/resolvers/dotnet/Azure.IoT.DeviceModelsRepository.Resolver/RepositoryHandler.cs
@@ -19,13 +19,13 @@ namespace Azure.IoT.DeviceModelsRepository.Resolver
         }
 
         public Uri RepositoryUri { get; }
-        public ResolverClientOptions Settings { get; }
+        public ResolverClientOptions ClientOptions { get; }
         public RepositoryTypeCategory RepositoryType { get; }
 
-        public RepositoryHandler(Uri repositoryUri, ResolverClientOptions settings = null, ILogger logger = null)
+        public RepositoryHandler(Uri repositoryUri, ResolverClientOptions options = null, ILogger logger = null)
         {
             _logger = logger ?? NullLogger.Instance;
-            Settings = settings ?? new ResolverClientOptions();
+            ClientOptions = options ?? new ResolverClientOptions();
             RepositoryUri = repositoryUri;
 
             _logger.LogTrace(StandardStrings.ClientInitWithFetcher(repositoryUri.Scheme));
@@ -101,7 +101,7 @@ namespace Azure.IoT.DeviceModelsRepository.Resolver
 
                 ModelMetadata metadata = new ModelQuery(result.Definition).GetMetadata();
 
-                if (Settings.DependencyResolution >= DependencyResolutionOption.Enabled)
+                if (ClientOptions.DependencyResolution >= DependencyResolutionOption.Enabled)
                 {
                     IList<string> dependencies = metadata.Dependencies;
 
@@ -133,7 +133,7 @@ namespace Azure.IoT.DeviceModelsRepository.Resolver
             {
                 return await this._modelFetcher.FetchAsync(
                     dtmi, this.RepositoryUri,
-                    Settings.DependencyResolution == DependencyResolutionOption.FromExpanded);
+                    ClientOptions.DependencyResolution == DependencyResolutionOption.FromExpanded);
             }
             catch (Exception ex)
             {

--- a/resolvers/dotnet/Azure.IoT.DeviceModelsRepository.Resolver/RepositoryHandler.cs
+++ b/resolvers/dotnet/Azure.IoT.DeviceModelsRepository.Resolver/RepositoryHandler.cs
@@ -19,13 +19,13 @@ namespace Azure.IoT.DeviceModelsRepository.Resolver
         }
 
         public Uri RepositoryUri { get; }
-        public ResolverClientSettings Settings { get; }
+        public ResolverClientOptions Settings { get; }
         public RepositoryTypeCategory RepositoryType { get; }
 
-        public RepositoryHandler(Uri repositoryUri, ILogger logger = null, ResolverClientSettings settings = null)
+        public RepositoryHandler(Uri repositoryUri, ResolverClientOptions settings = null, ILogger logger = null)
         {
             _logger = logger ?? NullLogger.Instance;
-            Settings = settings ?? new ResolverClientSettings();
+            Settings = settings ?? new ResolverClientOptions();
             RepositoryUri = repositoryUri;
 
             _logger.LogTrace(StandardStrings.ClientInitWithFetcher(repositoryUri.Scheme));
@@ -44,7 +44,7 @@ namespace Azure.IoT.DeviceModelsRepository.Resolver
 
         public string ToPath(string dtmi)
         {
-            if (!IsValidDtmi(dtmi))
+            if (!DtmiConventions.IsDtmi(dtmi))
             {
                 string invalidArgMsg = StandardStrings.InvalidDtmiFormat(dtmi);
                 _logger.LogError(invalidArgMsg);
@@ -52,11 +52,6 @@ namespace Azure.IoT.DeviceModelsRepository.Resolver
             }
 
             return _modelFetcher.GetPath(dtmi, this.RepositoryUri);
-        }
-
-        public static bool IsValidDtmi(string dtmi)
-        {
-            return DtmiConventions.IsDtmi(dtmi);
         }
 
         public async Task<IDictionary<string, string>> ProcessAsync(string dtmi)
@@ -71,7 +66,7 @@ namespace Azure.IoT.DeviceModelsRepository.Resolver
 
             foreach (string dtmi in dtmis)
             {
-                if (!IsValidDtmi(dtmi))
+                if (!DtmiConventions.IsDtmi(dtmi))
                 {
                     string invalidArgMsg = StandardStrings.InvalidDtmiFormat(dtmi);
                     _logger.LogError(invalidArgMsg);

--- a/resolvers/dotnet/Azure.IoT.DeviceModelsRepository.Resolver/ResolverClient.cs
+++ b/resolvers/dotnet/Azure.IoT.DeviceModelsRepository.Resolver/ResolverClient.cs
@@ -45,6 +45,6 @@ namespace Azure.IoT.DeviceModelsRepository.Resolver
 
         public Uri RepositoryUri  => repositoryHandler.RepositoryUri;
 
-        public ResolverClientOptions Settings => repositoryHandler.Settings;
+        public ResolverClientOptions ClientOptions => repositoryHandler.ClientOptions;
     }
 }

--- a/resolvers/dotnet/Azure.IoT.DeviceModelsRepository.Resolver/ResolverClient.cs
+++ b/resolvers/dotnet/Azure.IoT.DeviceModelsRepository.Resolver/ResolverClient.cs
@@ -1,53 +1,50 @@
 ﻿using Microsoft.Extensions.Logging;
 using System;
-using System.IO;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Azure.IoT.DeviceModelsRepository.Resolver
 {
-    public class ResolverClient
+    public class ResolverClient: IResolverClient
     {
-        readonly RepositoryHandler repositoryHandler = null;
+        public const string DefaultRepository = "https://devicemodels.azure.com";
+        private readonly RepositoryHandler repositoryHandler = null;
 
-        public static ResolverClient FromRemoteRepository(string repositoryUri, ILogger logger = null, ResolverClientSettings settings = null)
+        public ResolverClient() : this(new Uri(DefaultRepository), null, null) { }
+
+        public ResolverClient(Uri repositoryUri): this(repositoryUri, null, null) { }
+
+        public ResolverClient(Uri repositoryUri, ResolverClientOptions options): this(repositoryUri, options, null) { }
+
+        public ResolverClient(Uri repositoryUri, ResolverClientOptions options = null, ILogger logger = null)
         {
-            return new ResolverClient(new Uri(repositoryUri), logger, settings);
+            this.repositoryHandler = new RepositoryHandler(repositoryUri, options, logger);
         }
 
-        public static ResolverClient FromLocalRepository(string repositoryPath, ILogger logger = null, ResolverClientSettings settings = null)
-        {
-            repositoryPath = Path.GetFullPath(repositoryPath);
-            return new ResolverClient(new Uri($"file://{repositoryPath}"), logger, settings);
-        }
+        public ResolverClient(string repositoryUriStr) : this(repositoryUriStr, null, null) { }
 
-        public ResolverClient(Uri repositoryUri, ILogger logger = null, ResolverClientSettings settings = null)
-        {
-            this.repositoryHandler = new RepositoryHandler(repositoryUri, logger, settings);
-        }
+        public ResolverClient(string repositoryUriStr, ResolverClientOptions options) : 
+            this(repositoryUriStr, options, null) { }
 
-        public async Task<IDictionary<string, string>> ResolveAsync(string dtmi)
+        public ResolverClient(string repositoryUriStr, ResolverClientOptions options = null, ILogger logger = null) : 
+            this(new Uri(repositoryUriStr), options, logger) { }
+
+        public virtual async Task<IDictionary<string, string>> ResolveAsync(string dtmi)
         {
             return await this.repositoryHandler.ProcessAsync(dtmi);
         }
 
-        public async Task<IDictionary<string, string>> ResolveAsync(params string[] dtmis)
+        public virtual async Task<IDictionary<string, string>> ResolveAsync(IEnumerable<string> dtmis)
         {
             return await this.repositoryHandler.ProcessAsync(dtmis);
         }
 
-        public async Task<IDictionary<string, string>> ResolveAsync(IEnumerable<string> dtmis)
-        {
-            return await this.repositoryHandler.ProcessAsync(dtmis);
-        }
+        public virtual string GetPath(string dtmi) => repositoryHandler.ToPath(dtmi);
 
-        public string GetPath(string dtmi) => repositoryHandler.ToPath(dtmi);
-        
-        public static bool IsValidDtmi(string dtmi) => RepositoryHandler.IsValidDtmi(dtmi);
-        
+        public static bool IsValidDtmi(string dtmi) => DtmiConventions.IsDtmi(dtmi);
 
         public Uri RepositoryUri  => repositoryHandler.RepositoryUri;
 
-        public ResolverClientSettings Settings => repositoryHandler.Settings;
+        public ResolverClientOptions Settings => repositoryHandler.Settings;
     }
 }

--- a/resolvers/dotnet/Azure.IoT.DeviceModelsRepository.Resolver/ResolverClientOptions.cs
+++ b/resolvers/dotnet/Azure.IoT.DeviceModelsRepository.Resolver/ResolverClientOptions.cs
@@ -1,13 +1,13 @@
 ﻿namespace Azure.IoT.DeviceModelsRepository.Resolver
 {
-    public class ResolverClientSettings
+    public class ResolverClientOptions
     {
-        public ResolverClientSettings()
+        public ResolverClientOptions()
         {
             DependencyResolution = DependencyResolutionOption.Enabled;
         }
 
-        public ResolverClientSettings(DependencyResolutionOption resolutionOption)
+        public ResolverClientOptions(DependencyResolutionOption resolutionOption)
         {
             DependencyResolution = resolutionOption;
         }


### PR DESCRIPTION
* SDK candidate now targeting netstandard2.0
  * This means we have to downgrade our C# syntax from 8 to 7.
  * Also means `System.Text.Json` is **no longer** built-in we need an explicit dependency.
* Overhaul of ctors
  * Simplest ctor will automatically point to the prod model repo.
* `dmr-client` will initialize `ResolverClient` with `DependencyResolutionOption.FromExpanded` 
* Removal of factory initializers
* `ResolverClientSettings` renamed to `ResolverClientOptions` to better fit the nomenclature of Track2.
* One overload of `ResolveAsync()` (the one with params) had to be removed to prepare for plumbing of cancellation token where parameter order matters.
* Removes unnecessary `IsValidDtmi` from `RepositorHandler`, as the `ResolverClient` can call `DtmiConventions` directly.
* Add test for inline extends and variant
* Update tests