### PR TITLE
Support dotnet 5 in core tooling.

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -3,10 +3,15 @@ name: Merge
 on:
   push:
     branches: [ main, dev ]
-    paths-ignore: [ samples ]
+    paths-ignore:
+    - 'samples/**'
+    - '**.md'
+
   pull_request:
     branches: [ main, dev ]
-    paths-ignore: [ samples ]
+    paths-ignore:
+    - 'samples/**'
+    - '**.md'
 
 jobs:
   evaluating_dotnet_clients:
@@ -15,18 +20,27 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        dotnet: [ '3.1.x' ]
     steps:
     - uses: actions/checkout@v2
-    - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+
+    - name: Setup .NET Core 3.1.x
+      uses: actions/setup-dotnet@v1.7.2
       with:
-        dotnet-version: ${{ matrix.dotnet }}
-    - name: Install dependencies
+        dotnet-version: 3.1.x
+
+    - name: Setup .NET 5.0.x
+      uses: actions/setup-dotnet@v1.7.2
+      with:
+        dotnet-version: 5.0.x
+
+    - name: dotnet --info
+      run: dotnet --info
+
+    - name: Restore dependencies
       run: dotnet restore clients/dotnet
 
-    - name: Build
+    - name: Build solution Azure.Iot.ModelsRepository
       run: dotnet build --no-restore --configuration Release clients/dotnet
 
-    - name: Test
+    - name: Execute solution Azure.Iot.ModelsRepository test components
       run: dotnet test --no-restore --verbosity normal clients/dotnet

--- a/clients/dotnet/Azure.Iot.ModelsRepository.CLI.Tests/Azure.Iot.ModelsRepository.CLI.Tests.csproj
+++ b/clients/dotnet/Azure.Iot.ModelsRepository.CLI.Tests/Azure.Iot.ModelsRepository.CLI.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Version>0.0.1</Version>
     <Authors>Microsoft</Authors>

--- a/clients/dotnet/Azure.Iot.ModelsRepository.CLI.Tests/ClientInvokator.cs
+++ b/clients/dotnet/Azure.Iot.ModelsRepository.CLI.Tests/ClientInvokator.cs
@@ -1,5 +1,7 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Diagnostics;
 using System.IO;
+
 
 namespace Azure.Iot.ModelsRepository.CLI.Tests
 {
@@ -9,9 +11,11 @@ namespace Azure.Iot.ModelsRepository.CLI.Tests
 
         public static (int, string, string) Invoke(string commandArgs)
         {
+            string moniker = GetFrameworkMoniker();
+
             ProcessStartInfo cmdsi = new ProcessStartInfo("dotnet")
             {
-                Arguments = $"run -- {commandArgs}",
+                Arguments = $"run --framework {moniker} -- {commandArgs}",
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
                 UseShellExecute = false,
@@ -25,6 +29,22 @@ namespace Azure.Iot.ModelsRepository.CLI.Tests
             cmd.WaitForExit(10000);
 
             return (cmd.ExitCode, standardOut, standardError);
+        }
+
+        public static string GetFrameworkMoniker()
+        {
+            string lframeworkDesc = System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.ToLower();
+            if (lframeworkDesc.StartsWith(".net core 3.1"))
+            {
+                return "netcoreapp3.1";
+            }
+
+            if (lframeworkDesc.StartsWith(".net 5.0"))
+            {
+                return "net5.0";
+            }
+
+            throw new ArgumentException($"Unsupported framework: {lframeworkDesc}.");
         }
     }
 }

--- a/clients/dotnet/Azure.Iot.ModelsRepository.CLI/Azure.Iot.ModelsRepository.CLI.csproj
+++ b/clients/dotnet/Azure.Iot.ModelsRepository.CLI/Azure.Iot.ModelsRepository.CLI.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Copyright>Microsoft</Copyright>
     <Company>Microsoft</Company>

--- a/clients/dotnet/Azure.Iot.ModelsRepository.Samples/Azure.Iot.ModelsRepository.Samples.csproj
+++ b/clients/dotnet/Azure.Iot.ModelsRepository.Samples/Azure.Iot.ModelsRepository.Samples.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/clients/dotnet/Azure.Iot.ModelsRepository.Tests/Azure.Iot.ModelsRepository.Tests.csproj
+++ b/clients/dotnet/Azure.Iot.ModelsRepository.Tests/Azure.Iot.ModelsRepository.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Version>0.0.1</Version>
     <Authors>Microsoft</Authors>


### PR DESCRIPTION
* Introduces multi-framework target builds.
* CI will execute tests per supported framework.
* Support multi-framework in ClientInvokator.
* Keeps ResolverClient build at `netstandard2.0`.