### PR TITLE
Update dmr-client install scripts to support multi-target build

### DIFF
--- a/clients/dotnet/installer/install-dmr-client-linux.sh
+++ b/clients/dotnet/installer/install-dmr-client-linux.sh
@@ -2,12 +2,29 @@
 
 # Copyright (c) Microsoft Corporation MIT license
 
-source_archive_dir=dmr-tools-$(date +"%s")
-snapshot_ver="1.0.0-beta.1"
+dmr_client_ver="1.0.0-beta.1"
+snapshot_ver="dev"
 
-echo "Running dmr-client install script..."
-mkdir $source_archive_dir
-curl -# -o $source_archive_dir/snapshot-$snapshot_ver https://codeload.github.com/Azure/iot-plugandplay-models-tools/tar.gz/$snapshot_ver
-cd $source_archive_dir && { tar -xf snapshot-$snapshot_ver ; cd -; }
-dotnet pack $source_archive_dir/iot-plugandplay-models-tools-$snapshot_ver/clients/dotnet -v q -c Release
-dotnet tool install -g dmr-client --add-source $source_archive_dir/iot-plugandplay-models-tools-$snapshot_ver/clients/dotnet/Azure.Iot.ModelsRepository.CLI/bin/Release --version $snapshot_ver
+source_archive_dir=dmr-tools-$(date +"%s")
+framework_version=$(dotnet --version)
+framework_moniker=""
+
+if [[ "$framework_version" = "3.1"* ]]; then
+    framework_moniker="netcoreapp3.1"
+    pack_target="-p:NoWarn=NU5128 -p:TargetFrameworks=$framework_moniker"
+    framework_target="--framework $framework_moniker"
+elif [[ "$framework_version" = "5"* ]]; then
+    framework_moniker="net5.0"
+else
+    echo "dmr-client requires dotnetcore 3.1 SDK or dotnet 5.0 SDK. Detected '$framework_version'. " && exit 1
+fi
+
+echo "Executing dmr-client install script for $framework_moniker..."
+mkdir "$source_archive_dir"
+curl -# -o "$source_archive_dir/snapshot-$snapshot_ver" "https://codeload.github.com/Azure/iot-plugandplay-models-tools/tar.gz/$snapshot_ver"
+cd "$source_archive_dir" && { tar -xf "snapshot-$snapshot_ver" ; cd -; }
+root_cli_path="$source_archive_dir/iot-plugandplay-models-tools-$snapshot_ver/clients/dotnet/Azure.Iot.ModelsRepository.CLI"
+
+dotnet build -c Release --nologo $framework_target "$root_cli_path"
+dotnet pack -c Release --no-build --nologo $pack_target "$root_cli_path"
+dotnet tool install -g dmr-client $framework_target --add-source "$root_cli_path/bin/Release" --version $dmr_client_ver

--- a/clients/dotnet/installer/install-dmr-client-windows.ps1
+++ b/clients/dotnet/installer/install-dmr-client-windows.ps1
@@ -1,14 +1,33 @@
 # Copyright (c) Microsoft Corporation MIT license
 
-$source_archive_dir = "dmr-tools-" + [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
-$snapshot_ver = "1.0.0-beta.1"
+$dmr_client_ver="1.0.0-beta.1"
+$snapshot_ver="dev"
 
-Write-Host "Running dmr-client install script..."
+$source_archive_dir="dmr-tools-" + [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
+$framework_version=dotnet --version
+
+if ($framework_version.StartsWith("3.1")){
+    $framework_moniker="netcoreapp3.1"
+    $pack_target=@("-p:NoWarn=NU5128", "-p:TargetFrameworks=$framework_moniker")
+    $framework_target="--framework=$framework_moniker"
+}
+elseif ($framework_version.StartsWith("5")){
+    $framework_moniker="net5.0"
+}
+else {
+    Write-Host "dmr-client requires dotnetcore 3.1 SDK or dotnet 5.0 SDK. Detected '$framework_version'. "
+    exit 1
+}
+
+Write-Host "Executing dmr-client install script for $framework_moniker..."
 mkdir $source_archive_dir
 Invoke-WebRequest -Uri "https://codeload.github.com/Azure/iot-plugandplay-models-tools/tar.gz/$snapshot_ver" -OutFile "$source_archive_dir/snapshot-$snapshot_ver"
 Push-Location
 Set-Location -Path "$source_archive_dir"
 tar -xf "snapshot-$snapshot_ver"
 Pop-Location
-dotnet pack "$source_archive_dir/iot-plugandplay-models-tools-$snapshot_ver/clients/dotnet" -v q -c Release
-dotnet tool install -g dmr-client --add-source "$source_archive_dir/iot-plugandplay-models-tools-$snapshot_ver/clients/dotnet/Azure.Iot.ModelsRepository.CLI/bin/Release" --version $snapshot_ver
+$root_cli_path = "$source_archive_dir/iot-plugandplay-models-tools-$snapshot_ver/clients/dotnet/Azure.Iot.ModelsRepository.CLI"
+
+dotnet build -c Release --nologo $framework_target $root_cli_path
+dotnet pack -c Release --no-build --nologo $pack_target "$root_cli_path"
+dotnet tool install -g dmr-client $framework_target --add-source "$root_cli_path/bin/Release" --version $dmr_client_ver


### PR DESCRIPTION
- Scripts are sensitive on the dotnet environment to support either dotnet core 3.1 or dotnet 5.
- There is more complexity in the scripts due to not having a pre-built nuget package available.
- These are pointing at the dev branch right now. To be updated for the next release snapshot.
