### PR TITLE
tests(node resolver): resolution unit tests no dependency resolution

### DIFF
--- a/clients/node/tests/node/dtmiConventions.spec.ts
+++ b/clients/node/tests/node/dtmiConventions.spec.ts
@@ -71,7 +71,7 @@ describe('dtmiConventions', function () {
       }).to.throw('DTMI is incorrectly formatted. Ensure DTMI follows conventions.')
     })
 
-    it('should reformat a DTMI to a URL Path', function () {
+    it('should reformat a DTMI to a qualified URL path', function () {
       const validDtmi = 'dtmi:foobar:DeviceInformation;1'
       const fakeBasePath = 'https://contoso.com'
       const result = lib.dtmiToQualifiedPath(validDtmi, fakeBasePath, false)

--- a/clients/node/tests/node/dtmiConventions.spec.ts
+++ b/clients/node/tests/node/dtmiConventions.spec.ts
@@ -1,0 +1,88 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// TODO: once implemented replace this
+// import * as lib from '../../src/dtmiConventions'
+
+// fake class while lib not implemented
+class lib {
+
+  // @ts-ignore
+  static isValidDtmi(a: any): any {
+    return null
+  }
+
+  // @ts-ignore
+  static dtmiToPath(a: any): any {
+    return null
+  }
+
+  // @ts-ignore
+  static dtmiToQualifiedPath(a: any, b: any, c: any): any {
+    return null
+  }
+}
+
+
+import * as sinon from 'sinon'
+import { assert, expect } from 'chai'
+
+describe('dtmiConventions', function () {
+  afterEach(() => {
+    sinon.restore()
+  })
+  describe('isValidDtmi', function () {
+    // TODO: Will implement more rigorous testing of DTMI validation over multiple different valid DTMIs.
+    it('should validate a correctly formatted dtmi', function () {
+      const validDtmi = 'dtmi:azure:DeviceManagement:DeviceInformation;1'
+      const result = lib.isValidDtmi(validDtmi)
+      assert(result, 'valid dtmi not found as valid')
+    })
+
+    // TODO: Will implement more rigorous testing of DTMI validation over multiple different invalid DTMIs.
+    it('should invalidate an incorrectly formatted dtmi', function () {
+      const invalidDtmi = 'dtmiazure:DeviceManagement:DeviceInformation;1'
+      const result = lib.isValidDtmi(invalidDtmi)
+      assert(!result, 'invalid dtmi incorrectly labelled as valid')
+    })
+  })
+
+  describe('dtmiToPath', function () {
+    it('should fail if the dtmi is not formatted correctly', function () {
+      expect(() => {
+        const invalidDtmi = 'dtmiazure:DeviceManagement:DeviceInformation;1'
+        lib.dtmiToPath(invalidDtmi)
+      }).to.throw('DTMI is incorrectly formatted. Ensure DTMI follows conventions.')
+    })
+
+    it('should reformat a DTMI to a URL Path', function () {
+      const validDtmi = 'dtmi:azure:DeviceManagement:DeviceInformation;1'
+      const result = lib.dtmiToPath(validDtmi)
+      assert.deepEqual(result, '/dtmi/azure/devicemanagement/deviceinformation-1.json')
+    })
+  })
+
+  describe('dtmiToFullyQualifiedPath', function () {
+    it('should fail if the dtmi is not formatted correctly', function () {
+      expect(() => {
+        const invalidDtmi = 'dtmiazure:DeviceManagement:DeviceInformation;1'
+        const fakeBasePath = 'https://contoso.com'
+        lib.dtmiToQualifiedPath(invalidDtmi, fakeBasePath, false)
+      }).to.throw('DTMI is incorrectly formatted. Ensure DTMI follows conventions.')
+    })
+
+    it('should reformat a DTMI to a URL Path', function () {
+      const validDtmi = 'dtmi:foobar:DeviceInformation;1'
+      const fakeBasePath = 'https://contoso.com'
+      const result = lib.dtmiToQualifiedPath(validDtmi, fakeBasePath, false)
+      assert.deepEqual(result, 'https://contoso.com/dtmi/foobar/deviceinformation-1.json')
+    })
+
+    it('should add expanded to the path if specified', function () {
+      const validDtmi = 'dtmi:foobar:DeviceInformation;1'
+      const fakeBasePath = 'https://contoso.com'
+      const result = lib.dtmiToQualifiedPath(validDtmi, fakeBasePath, true)
+      assert.deepEqual(result, 'https://contoso.com/dtmi/foobar/deviceinformation-1.expanded.json')
+    })
+  })
+})

--- a/clients/node/tests/node/dtmiConventions.spec.ts
+++ b/clients/node/tests/node/dtmiConventions.spec.ts
@@ -55,7 +55,7 @@ describe('dtmiConventions', function () {
       }).to.throw('DTMI is incorrectly formatted. Ensure DTMI follows conventions.')
     })
 
-    it('should reformat a DTMI to a URL Path', function () {
+    it('should reformat a DTMI to a generic path', function () {
       const validDtmi = 'dtmi:azure:DeviceManagement:DeviceInformation;1'
       const result = lib.dtmiToPath(validDtmi)
       assert.deepEqual(result, '/dtmi/azure/devicemanagement/deviceinformation-1.json')

--- a/clients/node/tests/node/index.spec.ts
+++ b/clients/node/tests/node/index.spec.ts
@@ -58,7 +58,6 @@ describe('resolver - node', () => {
         })
         const localDirectory = path.resolve('./')
         const expectedFilePath = path.join(localDirectory, './dtmi/contoso/deletemedevice-1.json')
-        // sinon.stub(fs, 'readFile').callsArgWith(2, null, fakeData)
         // @ts-ignore
         sinon.stub(fs, 'readFile').callsFake((path, opts, cb) => {
           assert.deepEqual(path, expectedFilePath, 'path to dtdl incorrectly formatted.')

--- a/clients/node/tests/node/index.spec.ts
+++ b/clients/node/tests/node/index.spec.ts
@@ -1,0 +1,84 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// TODO: Once Implemented replace this
+// import * as lib from '../../src/index'
+import * as coreHttp from '@azure/core-http'
+
+import { assert } from 'chai'
+import * as sinon from 'sinon'
+
+import fs from 'fs'
+import path from 'path'
+
+// fake class while lib not implemented
+class lib {
+  // @ts-ignore
+  static resolve (a: any, b: any): any {
+    return null
+  }
+}
+
+describe('resolver - node', () => {
+  afterEach(() => {
+    sinon.restore()
+  })
+
+  describe('single resolution (no pseudo-parsing)', () => {
+    describe('given remote URL resolution', () => {
+      it('given successful execution, should return a promise that resolves to a mapping from a DTMI to a JSON object', function (done) {
+        const fakeDtmi: string = 'dtmi:contoso:FakeDeviceManagement:DeviceInformation;1'
+        const fakeEndpoint = 'devicemodels.contoso.com'
+        const expectedUri = 'https://devicemodels.contoso.com/dtmi/contoso/fakedevicemanagement/deviceinformation-1.json'
+        const fakeData = JSON.stringify({
+          fakeDtdl: 'fakeBodyAsText'
+        })
+        sinon.stub(coreHttp, 'ServiceClient')
+          .returns({
+            sendRequest: function (req: any) {
+              assert.deepEqual(req.url, expectedUri, 'URL not formatted for request correctly.')
+              return Promise.resolve({ bodyAsText: fakeData })
+            }
+          })
+
+        const resolveResult = lib.resolve(fakeDtmi, fakeEndpoint)
+        assert(resolveResult instanceof Promise, 'resolve method did not return a promise')
+        resolveResult.then((actualOutput: any) => {
+          assert.deepStrictEqual({ [fakeDtmi]: JSON.parse(fakeData) }, actualOutput)
+          done()
+        }).catch((err: any) => done(err))
+      })
+    })
+
+    describe('given local file resolution', () => {
+      it('given successful execution, should return a promise that resolves to a mapping from a DTMI to a JSON object', function (done) {
+        const fakeDtmi: string = 'dtmi:contoso:DeleteMeDevice;1'
+        const fakeData = JSON.stringify({
+          "fakeKey": "fakeValue"
+        })
+        const localDirectory = path.resolve('./')
+        const expectedFilePath = path.join(localDirectory, './dtmi/contoso/deletemedevice-1.json')
+        // sinon.stub(fs, 'readFile').callsArgWith(2, null, fakeData)
+        // @ts-ignore
+        sinon.stub(fs, 'readFile').callsFake((path, opts, cb) => {
+          assert.deepEqual(path, expectedFilePath, 'path to dtdl incorrectly formatted.')
+        })
+        const resolveResult = lib.resolve(fakeDtmi, localDirectory)
+        assert(resolveResult instanceof Promise, 'resolve method did not return a promise')
+        resolveResult.then((actualOutput: any) => {
+          assert.deepStrictEqual({ [fakeDtmi]: JSON.parse(fakeData) }, actualOutput)
+          done()
+        }).catch((err: any) => done(err))
+      })    })
+  })
+
+  describe('full resolution (using pseudo-parsing)', () => {
+    describe('given remote URL resolution', () => {
+
+    })
+
+    describe('given local file resolution', () => {
+
+    })
+  })
+})

--- a/clients/node/tests/node/index.spec.ts
+++ b/clients/node/tests/node/index.spec.ts
@@ -57,7 +57,7 @@ describe('resolver - node', () => {
           "fakeKey": "fakeValue"
         })
         const localDirectory = path.resolve('./')
-        const expectedFilePath = path.join(localDirectory, './dtmi/contoso/deletemedevice-1.json')
+        const expectedFilePath = path.join(localDirectory, 'dtmi/contoso/deletemedevice-1.json')
         // @ts-ignore
         sinon.stub(fs, 'readFile').callsFake((path, opts, cb) => {
           assert.deepEqual(path, expectedFilePath, 'path to dtdl incorrectly formatted.')


### PR DESCRIPTION
This provides behavior testing for the resolution without dependency resolution.

Only review in here the .spec.ts files. The other files are part of the first PR, and once the first PR is merged in they should be reflected in the dev branch.